### PR TITLE
Fix exit intent handler

### DIFF
--- a/lambda/py/lambda_function.py
+++ b/lambda/py/lambda_function.py
@@ -214,7 +214,7 @@ class ExitIntentHandler(AbstractRequestHandler):
 
     def can_handle(self, handler_input):
         return is_intent_name("AMAZON.CancelIntent")(handler_input) \
-            and is_intent_name("AMAZON.StopIntent")(handler_input)
+            or is_intent_name("AMAZON.StopIntent")(handler_input)
 
     def handle(self, handler_input):
         data = handler_input.attributes_manager.request_attributes["_"]


### PR DESCRIPTION
In the current case, there is no handler for neither cancel nor stop intent. This CR makes it so ExitIntentHandler can handle both.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
